### PR TITLE
Fix to make self closing elements end with `/>` instead of `>`

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,6 +90,9 @@ function htmlToJSX(html) {
 
       // Drop scripts ¯\_(ツ)_/¯
       .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+    
+      // Change self-closing elements to end with `/>` instead of `>`
+      .replace(/(?<=<(input|img|br|hr).*)>/g, '/>')
 
       // Trim the whitespace!
       .trim()


### PR DESCRIPTION
I didn't test this in your extension, but I tested it in my dev tools.

It uses a positive lookbehind group.

regexr.com/5gib4